### PR TITLE
Fixes PNG-to-PDF convertion by adding extra libs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ RUN apk --no-cache add bash mc \
             util-linux \
             libreoffice-common \
             libreoffice-writer \
+            libreoffice-base \
+            libreoffice-draw \
+            libreoffice-calc \
+            libreoffice-math \
+            libreoffice-impress \
             ttf-droid-nonlatin \
             ttf-droid \
             ttf-dejavu \


### PR DESCRIPTION
The following extra libraries might be required by LibreOffice in order to support a wider range of file formats:

- libreoffice-base
- libreoffice-draw
- libreoffice-calc
- libreoffice-math
- libreoffice-impress
